### PR TITLE
dominant-color-picker: Adds svg support

### DIFF
--- a/dominant-color.php
+++ b/dominant-color.php
@@ -21,18 +21,22 @@ function get_svg_colors($svg_url){
 };
 
 function get_top_left_pixel($image_location){
-	$ext = pathinfo($image_location, PATHINFO_EXTENSION);
-	if ($ext == 'png') {
-		$image= imagecreatefrompng($image_location);
-	} elseif ($ext == 'jpg' || $ext == 'jpeg') {
-		$image = imagecreatefromjpeg($image_location);
-	} elseif ($ext == 'gif') {
-		$image = imagecreatefromgif($image_location);
+	if (extension_loaded('gd')) {
+		$ext = pathinfo($image_location, PATHINFO_EXTENSION);
+		if ($ext == 'png') {
+			$image= imagecreatefrompng($image_location);
+		} elseif ($ext == 'jpg' || $ext == 'jpeg') {
+			$image = imagecreatefromjpeg($image_location);
+		} elseif ($ext == 'gif') {
+			$image = imagecreatefromgif($image_location);
+		}
+		$rgb = imagecolorat($image, 0, 0);
+		$colors = imagecolorsforindex($image, $rgb);
+		$colorHex = sprintf("#%02x%02x%02x", $colors["red"], $colors["green"], $colors["blue"]);
+		return $colorHex;
+	} else {
+		return false;
 	}
-	$rgb = imagecolorat($image, 0, 0);
-	$colors = imagecolorsforindex($image, $rgb);
-	$colorHex = sprintf("#%02x%02x%02x", $colors["red"], $colors["green"], $colors["blue"]);
-	return $colorHex;
 }
 
 // Add our css to the admin
@@ -80,8 +84,12 @@ function update_attachment_color_dominance($attachment_id) {
 		foreach($palette as $rgb) {
 			$hex_palette[] = rgb2hex($rgb);
 		}
-		$hex_palette[] = get_top_left_pixel($post->guid);
-		$palette[] = hex2rgb(end($hex_palette));
+		
+		$top_left = get_top_left_pixel($post->guid);
+		if ($top_left !== false){
+			$hex_palette[] = $top_left;
+			$palette[] = hex2rgb($top_left);
+		}
 	}
 	$palette = array_unique($palette);
 	$hex_palette = array_unique($hex_palette);

--- a/dominant-color.php
+++ b/dominant-color.php
@@ -1,12 +1,12 @@
 <?php
 /*
-	Plugin Name: Dominant Color By Sproutsocial
+	Plugin Name: Dominant Color
 	Description: Add an attachment meta option to provide the hex of the most dominant color of an image.
-	Version: 1.0
-    Text Domain: dominant-color-Sproutsocial
-	Author: Previously Liam Gladdy, now Sproutsocial.
+	Version: 2.2.0
+  Text Domain: dominant-color
+	Author: Liam Gladdy
+	Author URI: https://gladdy.uk
 */
-
 require('vendor/autoload.php');
 use ColorThief\ColorThief;
 

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,10 @@ Alternatively, you can use the meta keys "color_palette_rgb" and "color_palette_
 
 == Changelog ==
 
+2.2
+---
+Adds SVG Support and also now gives you the top left pixel as the last color. Thanks to Eric Mikkelsen at Sprout Social.
+
 2.0
 ---
 


### PR DESCRIPTION
This now reads in all the hex values from an SVG and sets the first one as the dominant color.